### PR TITLE
Add Netlify redirects for push history state

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
Fixes #22. Also closes #19.

In order to deploy our React app properly to Netlify, we need to set up Redirects ([see docs](https://www.netlify.com/docs/redirects/)).

Relevant excerpt:
>If you’re developing a single page app and want history pushstate to work so you get clean URLs, you’ll want to enable the following rewrite rule:
>`/*    /index.html   200`
>This will effectively serve the index.html instead of giving a 404 no matter what URL the browser requests.

I decided to add it to a `netlify.toml` instead of `_redirects` so that all Netlify settings can live in the same configuration file.

### Testing

Check out Netlify's automated branch deployment preview (either see the link on the `deploy/netlify` CI check below or click this [link](https://deploy-preview-23--quizzical-mccarthy-0289ae.netlify.com/login)). See if you can refresh the page or paste the URL in the new tab without having Netlify 404 on us.
