### PR TITLE
refactor: Abstract API layer to allow for multiple base URLs

### DIFF
--- a/src/Shared/Authorization/AuthProvider.tsx
+++ b/src/Shared/Authorization/AuthProvider.tsx
@@ -30,7 +30,7 @@ const Provider: React.FunctionComponent = ({ children }) => {
   // helper function to update the provider from a consumer
   const updateProvider = (response: ILoginResponse) => {
     localStorage.setItem("token", response.token);
-    api.setJWT(response.token);
+    userAPI.setJWT(response.token);
     return fetchInfo();
   };
 
@@ -38,13 +38,13 @@ const Provider: React.FunctionComponent = ({ children }) => {
   const loadFromCache = () => {
     const jwt = localStorage.getItem("token");
     if (jwt) {
-      api.setJWT(jwt);
+      userAPI.setJWT(jwt);
     }
   };
 
   const clearStateAndCache = () => {
     setUserInfo(undefined);
-    api.clearJWT();
+    userAPI.clearJWT();
     localStorage.clear();
   };
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -21,12 +21,16 @@ class API {
   public endpoints: { [endpoint: string]: IEndpoints };
   private instance: AxiosInstance;
 
-  constructor() {
+  constructor(baseURL: string) {
     this.endpoints = {};
     this.instance = axios.create({
-      baseURL: "https://jobhub-authentication-staging.herokuapp.com",
-      timeout: 5000
+      baseURL,
+      timeout: 10000
     });
+  }
+
+  public createEntities = (entities: string[]) => {
+    entities.forEach((entity) => this.createEntity(entity));
   }
 
   public createEntity = (entityUrl: string) => {
@@ -65,6 +69,4 @@ class API {
   };
 }
 
-const myAPI = new API();
-
-export default myAPI;
+export default API;

--- a/src/api/userAPI.ts
+++ b/src/api/userAPI.ts
@@ -1,10 +1,9 @@
 import { AxiosPromise } from "axios";
 
-import api from "./api";
-
 import UserType from "../config/types/accountTypes";
 import ILoginResponse from "../config/types/loginResponse";
 import IUser from "../config/types/user";
+import API from "./api";
 
 enum UserEndpoints {
   USERS = "/users",
@@ -15,19 +14,25 @@ enum UserEndpoints {
 }
 
 class UserAPI {
+  private api: API;
   constructor() {
-    api.createEntity(UserEndpoints.USERS);
-    api.createEntity(UserEndpoints.SELF);
-    api.createEntity(UserEndpoints.LOGIN);
-    api.createEntity(UserEndpoints.REGISTER);
-    api.createEntity(UserEndpoints.RESEND_EMAIL);
+    this.api = new API("https://jobhub-authentication-staging.herokuapp.com");
+    this.api.createEntities(Object.values(UserEndpoints));
+  }
+
+  public setJWT = (token: string) => {
+    this.api.setJWT(token);
+  }
+
+  public clearJWT = () => {
+    this.api.clearJWT();
   }
 
   public login = (payload: { email: string; password: string }) => {
-    return api.endpoints[UserEndpoints.LOGIN]
+    return this.api.endpoints[UserEndpoints.LOGIN]
       .create(payload)
       .then(({ data }) => {
-        api.setJWT(data.token);
+        this.api.setJWT(data.token);
         return data as ILoginResponse;
       });
   };
@@ -37,15 +42,15 @@ class UserAPI {
     password: string;
     type: UserType;
   }) => {
-    return api.endpoints[UserEndpoints.REGISTER].create(payload);
+    return this.api.endpoints[UserEndpoints.REGISTER].create(payload);
   };
 
   public getSelf = () => {
-    return api.endpoints[UserEndpoints.SELF].getAll() as AxiosPromise<IUser>;
+    return this.api.endpoints[UserEndpoints.SELF].getAll() as AxiosPromise<IUser>;
   };
 
   public resendVerification = (payload: { email: string }) => {
-    return api.endpoints[UserEndpoints.RESEND_EMAIL].create(payload);
+    return this.api.endpoints[UserEndpoints.RESEND_EMAIL].create(payload);
   };
 }
 


### PR DESCRIPTION
Closes #30.

`API` is now a class that can be instantiated multiple times, allowing for each individual API to have its own base URL and settings. Endpoint strings have been abstracted into an enum, andcreating multiple entities has also been abstracted into a helper function based on iterating over that enum.

Please check for no regressions.